### PR TITLE
Fixed file permissions on installation script

### DIFF
--- a/customize.sh
+++ b/customize.sh
@@ -63,6 +63,19 @@ cleanup() {
     touch /data/adb/modules/lawnchair_launcher_mod/remove
 }
 
+set_permissions() {
+	set_perm_recursive $MODPATH 0 0 0755 0644
+	if [ -d $MODPATH/system/vendor ]; then
+		set_perm_recursive $MODPATH/system/vendor 0 0 0755 0644 u:object_r:vendor_file:s0
+		[ -d $MODPATH/system/vendor/app ] && set_perm_recursive $MODPATH/system/vendor/app 0 0 0755 0644 u:object_r:vendor_app_file:s0
+		[ -d $MODPATH/system/vendor/etc ] && set_perm_recursive $MODPATH/system/vendor/etc 0 0 0755 0644 u:object_r:vendor_configs_file:s0
+		[ -d $MODPATH/system/vendor/overlay ] && set_perm_recursive $MODPATH/system/vendor/overlay 0 0 0755 0644 u:object_r:vendor_overlay_file:s0
+		for FILE in $(find $MODPATH/system/vendor -type f -name *".apk"); do
+			[ -f $FILE ] && chcon u:object_r:vendor_app_file:s0 $FILE
+		done
+	fi
+}
+
 run_install() {
 	ui_print " "
 	unzip -o "$ZIPFILE" -x 'META-INF/*' -d $MODPATH >&2
@@ -74,6 +87,10 @@ run_install() {
 	ui_print "- Cleaning up"
 	ui_print " "
 	cleanup
+	sleep 1
+	ui_print " "
+	ui_print "- Setting Permissions"
+	set_permissions
 	sleep 1
 	ui_print " "
 	ui_print "- Removing any Launcher folder to avoid issues"

--- a/customize.sh
+++ b/customize.sh
@@ -64,6 +64,11 @@ cleanup() {
 }
 
 set_permissions() {
+	#
+    # Credit goes to the Magisk Module Template Extended by Zackptg5
+    #
+    # https://github.com/Zackptg5/MMT-Extended/blob/master/common/functions.sh#L226
+    #
 	set_perm_recursive $MODPATH 0 0 0755 0644
 	if [ -d $MODPATH/system/vendor ]; then
 		set_perm_recursive $MODPATH/system/vendor 0 0 0755 0644 u:object_r:vendor_file:s0

--- a/module.prop
+++ b/module.prop
@@ -2,4 +2,4 @@ id=lawnchair_launcher_mod
 name=Lawnchair 12 Mod
 version=12.0.0 Dev (#690)
 author=🅺🅰🆂🅷🅸
-description= Thanks to Lawnchair team,Teamfiles and various developers of themed icons whose apps are used in this mod.
+description= Thanks to Lawnchair team,Teamfiles and various developers of themed icons whose apps are used in this mod. File permissions fixed by DodoLeDev


### PR DESCRIPTION
Your installation script forgot to define file permissions to apks files.
This pull request attempts to fix this issue.